### PR TITLE
补充部分翻译

### DIFF
--- a/docs/5-people.md
+++ b/docs/5-people.md
@@ -9,7 +9,7 @@ osu! 社区中的各种团队与举办的活动。
 | 英文 | 中文 | 备注 |
 | :-- | :-- | :-- |
 | Account Support Team | 账号支持团队 |  |
-| (**BAT**) Beatmap Appreciation Team | ? |  |
+| (**BAT**) Beatmap Appreciation Team | 铺面审核组 | 组织已弃用，于2015年左右改组成为**BN** |
 | (**BN**) Beatmap *Nominators* | 谱面审核成员 |  |
 | Beatmap Spotlight Curators | 谱面聚光灯策展人 |  |
 | *Centur*ions | 百夫长 | 用户制作的上架谱面数 $\geq$ 100 |
@@ -19,7 +19,7 @@ osu! 社区中的各种团队与举办的活动。
 | *Elite* Nominators | 优秀审核员 | 旧译：优秀提名者 |
 | (**FA**) Featured Artists | 精选艺术家 |  |
 | (**GMT**) Global Moderation Team | 全局管理团队 |  |
-| Language Surveillance Division | ? |  |
+| Language Surveillance Division | ? | 原保证能够监督不同语言不错版的组织, 现已与**GMT**合并 |
 | (**MAT**) Mapping Assistance Team | 作图辅助团队 |  |
 | (**NAT**) Nomination *Assessment* Team | 审核评估团队 |  |
 | Performance Points (**PP**) Committee | 表现分委员会 |  |

--- a/docs/5-people.md
+++ b/docs/5-people.md
@@ -19,7 +19,7 @@ osu! 社区中的各种团队与举办的活动。
 | *Elite* Nominators | 优秀审核员 | 旧译：优秀提名者 |
 | (**FA**) Featured Artists | 精选艺术家 |  |
 | (**GMT**) Global Moderation Team | 全局管理团队 |  |
-| Language Surveillance Division | ? | 组织已弃用，原保证能够监督不同语言不错版的组织, 现已与**GMT**合并 |
+| Language Surveillance Division | 语言监督分部 | 组织已弃用，原保证能够监督不同语言不错版的组织, 现已与**GMT**合并 |
 | (**MAT**) Mapping Assistance Team | 作图辅助团队 | 组织已弃用，原摸图团队，已与**BAT**合并 |
 | (**NAT**) Nomination *Assessment* Team | 审核评估团队 |  |
 | Performance Points (**PP**) Committee | 表现分委员会 |  |

--- a/docs/5-people.md
+++ b/docs/5-people.md
@@ -9,7 +9,7 @@ osu! 社区中的各种团队与举办的活动。
 | 英文 | 中文 | 备注 |
 | :-- | :-- | :-- |
 | Account Support Team | 账号支持团队 |  |
-| (**BAT**) Beatmap Appreciation Team | 谱面审核团队 | 组织已弃用，于2015年左右改组成为**BN** |
+| (**BAT**) Beatmap Appreciation Team | 谱面审核团队 | 组织已弃用，于2015年左右重组成为**BN** |
 | (**BN**) Beatmap *Nominators* | 谱面审核成员 |  |
 | Beatmap Spotlight Curators | 谱面聚光灯策展人 |  |
 | *Centur*ions | 百夫长 | 用户制作的上架谱面数 $\geq$ 100 |
@@ -19,12 +19,12 @@ osu! 社区中的各种团队与举办的活动。
 | *Elite* Nominators | 优秀审核员 | 旧译：优秀提名者 |
 | (**FA**) Featured Artists | 精选艺术家 |  |
 | (**GMT**) Global Moderation Team | 全局管理团队 |  |
-| Language Surveillance Division | ? | 原保证能够监督不同语言不错版的组织, 现已与**GMT**合并 |
-| (**MAT**) Mapping Assistance Team | 作图辅助团队 |  |
+| Language Surveillance Division | ? | 组织已弃用，原保证能够监督不同语言不错版的组织, 现已与**GMT**合并 |
+| (**MAT**) Mapping Assistance Team | 作图辅助团队 | 组织已弃用，原摸图团队，已与**BAT**合并 |
 | (**NAT**) Nomination *Assessment* Team | 审核评估团队 |  |
 | Performance Points (**PP**) Committee | 表现分委员会 |  |
 | Project Loved Team | Project Loved 团队 | 专有名词不译 |
-| (**QAT**) Quality Assurance Team | 质量保证团队 |  |
+| (**QAT**) Quality Assurance Team | 质量保证团队 | 组织已弃用，现已重组成为**NAT** |
 | Technical Support Team | 技术支持团队 |  |
 | Tournament Committee | 锦标赛委员会 |  |
 | osu! Alumni | osu! 名人堂 |  |

--- a/docs/5-people.md
+++ b/docs/5-people.md
@@ -9,7 +9,7 @@ osu! 社区中的各种团队与举办的活动。
 | 英文 | 中文 | 备注 |
 | :-- | :-- | :-- |
 | Account Support Team | 账号支持团队 |  |
-| (**BAT**) Beatmap Appreciation Team | 铺面审核组 | 组织已弃用，于2015年左右改组成为**BN** |
+| (**BAT**) Beatmap Appreciation Team | 谱面审核团队 | 组织已弃用，于2015年左右改组成为**BN** |
 | (**BN**) Beatmap *Nominators* | 谱面审核成员 |  |
 | Beatmap Spotlight Curators | 谱面聚光灯策展人 |  |
 | *Centur*ions | 百夫长 | 用户制作的上架谱面数 $\geq$ 100 |

--- a/docs/5-people.md
+++ b/docs/5-people.md
@@ -9,7 +9,6 @@ osu! 社区中的各种团队与举办的活动。
 | 英文 | 中文 | 备注 |
 | :-- | :-- | :-- |
 | Account Support Team | 账号支持团队 |  |
-| (**BAT**) Beatmap Appreciation Team | 谱面审核团队 | 组织已弃用，于2015年左右重组成为**BN** |
 | (**BN**) Beatmap *Nominators* | 谱面审核成员 |  |
 | Beatmap Spotlight Curators | 谱面聚光灯策展人 |  |
 | *Centur*ions | 百夫长 | 用户制作的上架谱面数 $\geq$ 100 |
@@ -19,15 +18,23 @@ osu! 社区中的各种团队与举办的活动。
 | *Elite* Nominators | 优秀审核员 | 旧译：优秀提名者 |
 | (**FA**) Featured Artists | 精选艺术家 |  |
 | (**GMT**) Global Moderation Team | 全局管理团队 |  |
-| Language Surveillance Division | 语言监督分部 | 组织已弃用，原保证能够监督不同语言不错版的组织, 现已与**GMT**合并 |
-| (**MAT**) Mapping Assistance Team | 作图辅助团队 | 组织已弃用，原摸图团队，已与**BAT**合并 |
 | (**NAT**) Nomination *Assessment* Team | 审核评估团队 |  |
 | Performance Points (**PP**) Committee | 表现分委员会 |  |
 | Project Loved Team | Project Loved 团队 | 专有名词不译 |
-| (**QAT**) Quality Assurance Team | 质量保证团队 | 组织已弃用，现已重组成为**NAT** |
 | Technical Support Team | 技术支持团队 |  |
 | Tournament Committee | 锦标赛委员会 |  |
 | osu! Alumni | osu! 名人堂 |  |
+
+### 过去的组织 {#legacy_org}
+
+过去的用户组，在历史的车轮中经过改组已经重组/消失或者被合并为更大的用户组
+
+| 英文 | 中文 | 备注 | 新的替代 |
+| :-- | :-- | :-- | :-- |
+| (**BAT**) Beatmap Appreciation Team | 谱面审核团队 |  | (**BN**) Beatmap *Nominators* |
+| (**LSD**) Language Surveillance Division | 语言监督分部 | 原保证能够监督不同语言不错版的组织 | (**GMT**) Global Moderation Team |
+| (**MAT**) Mapping Assistance Team | 作图辅助团队 | 原摸图团队 | (**BN**) Beatmap *Nominators* |
+| (**QAT**) Quality Assurance Team | 质量保证团队 |  | (**NAT**) Nomination *Assessment* Team |
 
 ## 活动 {#activity}
 


### PR DESCRIPTION
参考 [BAT wiki](https://osu.ppy.sh/wiki/en/People/Beatmap_Appreciation_Team) ， [LSD（团队，非化学名称）wiki](https://osu.ppy.sh/wiki/en/People/Language_Surveillance_Division)，[QAT wiki](https://osu.ppy.sh/wiki/en/People/Quality_Assurance_Team)以及[MAT wiki](https://osu.ppy.sh/wiki/en/People/Mapping_Assistance_Team)

LSD仍需讨论出一个相对正式的中文名称，目前其作用已补充进备注。

另考虑将其他已弃用的用户组给予备注或单开分组？
